### PR TITLE
bug fix for makePTA()

### DIFF
--- a/Pmetrics/R/makePTA.R
+++ b/Pmetrics/R/makePTA.R
@@ -190,8 +190,8 @@ makePTA <- function(simdata,simlabels,targets,
     
     
     # if free.fraction not 1, multiply by free.fraction
-    if (free.fraction != 1) {simdata <- lapply(1:nsim, function(x) {simdata[[x]]$obs <- simdata[[x]]$obs * free.fraction ; simdata[[x]]})} 
-    
+    if (free.fraction != 1) {simdata <- lapply(1:nsim, function(x) {simdata[[x]]$obs$out <- simdata[[x]]$obs$out * free.fraction ; simdata[[x]]})} 
+
     if (!simTarg & target.type == "time") maxpb <- nsim * ntarg else maxpb <- nsim
     
     pb <- txtProgressBar(min = 0, max = maxpb, style = 3)
@@ -384,7 +384,7 @@ makePTA <- function(simdata,simlabels,targets,
     
     if (!exists("sim.labels")) sim.labels <- attr(simdata, "simlabels")
     simTarg <- attr(simdata, "simTarg")
-    target.type =  attr(simdata, "type")
+    target.type <- attr(simdata, "type")
     
     cat("A PMpta object of type \"", target.type, "\" and original success threshold of ", attr(simdata, "success"), " will be used for calculations.\n",  sep = "")
     cat("Recalculating with a new success threshold of ", success, ".\n",  sep = "")

--- a/Pmetrics/R/summaryPMpta.R
+++ b/Pmetrics/R/summaryPMpta.R
@@ -25,9 +25,9 @@ summary.PMpta <- function(x,ci=0.95,...){
   require(reshape2)
   simTarg <- 1+as.numeric(attr(x,"simTarg")) #1 if missing or set, 2 if random
   if(length(simTarg)==0) simTarg <- 1
+  nsim <- length(unique(x$results$simnum))
   
   if(simTarg==1){ #set targets
-    nsim <- length(unique(x$results$simnum))
     ntarg <- length(unique(x$results$target))
     pdi.median <- tapply(x$results$pdi,list(x$results$target,x$results$simnum),median,na.rm=T)
     pdi.lower <- tapply(x$results$pdi,list(x$results$target,x$results$simnum),quantile,probs=0.5-ci/2,na.rm=T)


### PR DESCRIPTION
The free fraction multiplication was on the $obs instead of $obs$out,
which resulted in everything being multiplied, including observation
times. My bad.
Also including the fix for PMpta.summary, but I guess you may have changed that already.