### PR TITLE
makeNCA fix for missing subjects

### DIFF
--- a/Pmetrics/R/makeNCA.R
+++ b/Pmetrics/R/makeNCA.R
@@ -220,6 +220,11 @@ makeNCA <- function(x,postPred=F,include,exclude,input=1,icen="median",outeq=1,b
     mdata2 <- filterResults[[1]]
     startTimes <- filterResults[[2]]
     endTimes <- filterResults[[3]]
+   
+    # delete start and end times of subjects excluded from the run and missing from post object
+    startTimes <- startTimes[unique(post$id)]
+    endTimes <- endTimes[unique(post$id)]
+    
     #now filter post by time
     whichtime <<- 0
     post2 <- ddply(post,.(id),timeFilter,startTimes,endTimes)

--- a/Pmetrics/R/makeNCA.R
+++ b/Pmetrics/R/makeNCA.R
@@ -303,6 +303,7 @@ makeNCA <- function(x,postPred=F,include,exclude,input=1,icen="median",outeq=1,b
         warning("Subjects No. ", paste(missing_from_post, collapse = ", "),  " are missing from the post object and were excluded.", call. = F)
         mdata <- subset(mdata,!sub("[[:space:]]+","",as.character(mdata$id)) %in% as.character(missing_from_post))
         post <- subset(post,!sub("[[:space:]]+","",as.character(post$id)) %in% as.character(missing_from_post))
+        if (length(unique(mdata$id))==0) stop("No subjects left to analyze.", call. = F)
       }
       dataList <- conv_post(post=post,mdata=mdata,input=input,outeq=outeq,block=block,icen=icen,start=start,end=end,first=first,last=last)
     } else {      


### PR DESCRIPTION
In conv_post, delete start and end times of subjects that were excluded from the run and are
missing from the post object.