### PR TITLE
Added argument to skip user input during PMbuild

### DIFF
--- a/R/PMbuild.R
+++ b/R/PMbuild.R
@@ -3,13 +3,14 @@
 #'
 #' @title Build Pmetrics
 #' @author Michael Neely
+#' @param auto If true, Pmetrics will not prompt the user before downloading and installing gfortran and required components
 #' @export
 
 
 
-PMbuild <- function() {
+PMbuild <- function(auto = FALSE) {
 
-  if (.check_and_install_gfortran()) {
+  if (.check_and_install_gfortran(auto = auto)) {
 
     currwd <- getwd()
     OS <- getOS()
@@ -96,7 +97,7 @@ PMbuild <- function() {
   }
 }
 
-.check_and_install_gfortran <- function() {
+.check_and_install_gfortran <- function(auto = FALSE) {
   #restore user defaults - deprecated
   #if(length(system.file(package="Defaults"))==1){PMreadDefaults()}
   sch_str <- c("which -s gfortran", "where gfortran", "which -s gfortran")
@@ -107,8 +108,10 @@ PMbuild <- function() {
       cat("Pmetrics cannot find required compiled binary files.\n")
       if (system(sch_str[OS]) != 0) {
         cat("Pmetrics cannot detect gfortran and will attempt to download and install all components.\n")
-        input <- tolower(readline(prompt = "Do you agree? (Y/N)"))
-        if (substr(input, 1, 1) == "y") {
+        if (auto == FALSE) {
+          input <- tolower(readline(prompt = "Do you agree? (Y/N)"))
+        }
+        if (substr(input, 1, 1) == "y" || auto == TRUE) {
           if (.installOrUpdateGfortran()) {
             cat("Pmetrics has installed gfortran and will now compile required binary files.\n")
             cat("Pmetrics has anonymously registered your installation of this version.\nLAPKB does not collect or store any personal or identifying information.")

--- a/R/PMbuild.R
+++ b/R/PMbuild.R
@@ -3,14 +3,13 @@
 #'
 #' @title Build Pmetrics
 #' @author Michael Neely
-#' @param auto If true, Pmetrics will not prompt the user before downloading and installing gfortran and required components
 #' @export
 
 
 
-PMbuild <- function(auto = FALSE) {
+PMbuild <- function() {
 
-  if (.check_and_install_gfortran(auto = auto)) {
+  if (.check_and_install_gfortran()) {
 
     currwd <- getwd()
     OS <- getOS()
@@ -97,7 +96,7 @@ PMbuild <- function(auto = FALSE) {
   }
 }
 
-.check_and_install_gfortran <- function(auto = FALSE) {
+.check_and_install_gfortran <- function() {
   #restore user defaults - deprecated
   #if(length(system.file(package="Defaults"))==1){PMreadDefaults()}
   sch_str <- c("which -s gfortran", "where gfortran", "which -s gfortran")
@@ -108,10 +107,8 @@ PMbuild <- function(auto = FALSE) {
       cat("Pmetrics cannot find required compiled binary files.\n")
       if (system(sch_str[OS]) != 0) {
         cat("Pmetrics cannot detect gfortran and will attempt to download and install all components.\n")
-        if (auto == FALSE) {
-          input <- tolower(readline(prompt = "Do you agree? (Y/N)"))
-        }
-        if (substr(input, 1, 1) == "y" || auto == TRUE) {
+        input <- tolower(readline(prompt = "Do you agree? (Y/N)"))
+        if (substr(input, 1, 1) == "y") {
           if (.installOrUpdateGfortran()) {
             cat("Pmetrics has installed gfortran and will now compile required binary files.\n")
             cat("Pmetrics has anonymously registered your installation of this version.\nLAPKB does not collect or store any personal or identifying information.")

--- a/R/makePost.R
+++ b/R/makePost.R
@@ -123,7 +123,7 @@ makePost <- function(run,NPdata) {
     #count 0 times per subject, icen, and outeq - should be at least 1 for each
     blocks <- tapply(post$time,list(post$id,post$icen,post$outeq),function(x) sum(x==0))
     
-    blocks2 <- unlist(mapply(function(x) 1:x,blocks))
+    blocks2 <- unlist(mapply(function(x) seq_along(x),blocks))
     time0 <- c(which(post$time==0),1+nrow(post))
     blocks3 <- rep(blocks2,times=diff(time0))
     post$block <- blocks3


### PR DESCRIPTION
In order to facilitate automatic installations of Pmetrics, an argument was added to circumvent user input.