### PR TITLE
Only use trailing arguments in NPrepScript

### DIFF
--- a/inst/report/NPrepScript.R
+++ b/inst/report/NPrepScript.R
@@ -1,7 +1,8 @@
 require(Pmetrics)
-wd <- commandArgs()[6]
-icen <- commandArgs()[7]
-parallel <- as.logical(commandArgs()[8])
+args <- commandArgs(trailingOnly=TRUE)
+wd <- args[1]
+icen <- args[2]
+parallel <- as.logical(args[3])
 setwd(wd)
 PMreport(wd,icen=icen,type="NPAG",parallel=parallel)
 


### PR DESCRIPTION
The number of standard arguments may vary between environments and operating systems.
To ensure compatability only trailing arguments should be considered.

This solves an issue where the report script will not run when installing Pmetrics on Ubuntu (only tested in Docker), due to an exception in `setwd(wd)`.