### PR TITLE
Update makeNCA.R

### DIFF
--- a/R/makeNCA.R
+++ b/R/makeNCA.R
@@ -394,9 +394,15 @@ makeNCA <- function(x, postPred = F, include, exclude, input = 1, icen = "median
 
     NCA[i, 10] <- max(temp$out) # cmax
     NCA[i, 11] <- temp$tad[which(temp$out == NCA[i, 10])][1] # tmax
-    NCA[i, 2] <- makeAUC(temp, out ~ tad, icen = icen, outeq = outeq, block = block)[, 2] # auc
+    
+    # AUC
+    auc = makeAUC(temp, out ~ tad, icen = icen, outeq = outeq, block = block)$tau
+    NCA[i, 2] <- ifelse(length(auc) == 0, NA, auc)
+
+    #AUMC
     temp2 <- data.frame(id = temp$id, tad = temp$tad, out = temp$tad * temp$out)
-    NCA[i, 3] <- makeAUC(temp2, out ~ tad, icen = icen, outeq = outeq, block = block)[, 2] # aumc
+    aumc = makeAUC(temp2, out ~ tad, icen = icen, outeq = outeq, block = block)$tau
+    NCA[i, 3] <-  ifelse(length(aumc) == 0, NA, aumc)
 
     if (nrow(temp) >= 5) {
       temp <- tail(temp, terminal)


### PR DESCRIPTION
1) Update code to use `$tau` instead of subsetting with square brackets, to avoid passing a tibble to a matrix cell, causing the matrix to turn into a list, which in turn produces the error "subscript out of bounds". 

2) In the cases of no AUC being calculated, and an empty tibble is return from makeAUC, the length on `tau` will be zero. As replacements in a matrix cannot be zero, check for this, and if so return `NA`.

Tested on a custom dataset and the dataset included in `NPex`, but could definitely use another few tests.

