### PR TITLE
When specifying run directory in PM_fit, stop if directory does not exist

### DIFF
--- a/R/PM_fit.R
+++ b/R/PM_fit.R
@@ -47,6 +47,9 @@ PM_fit <- R6::R6Class("PM_fit",
     #' @param rundir This argument specifies an *existing* folder that will store the run inside.
     run = function(..., engine = "NPAG", rundir = getwd()) {
       wd <- getwd()
+      if (!dir.exists(rundir)) {
+          stop("You have specified a directory that does not exist, please create it first.")
+       }
       setwd(rundir)
       engine <- tolower(engine)
       if (inherits(private$model, "PM_model_legacy")) {


### PR DESCRIPTION
The function will now `stop()` with an appropriate error message if the specified run directory does not exist.