### PR TITLE
Remove print statement

### DIFF
--- a/R/PMreport.R
+++ b/R/PMreport.R
@@ -362,7 +362,6 @@ makeRdata <- function(wd, remote, reportType) {
 
 # function to process data.frames
 makeHTMLdf <- function(df, ndigit) {
-  print(df)
   Nrow <- nrow(df)
   Ncol <- ncol(df)
   dfScript <- vector("character")


### PR DESCRIPTION
Remove print statement in makeHTMLdf in order to reduce unnecessary bloat.

Resolves #123 after @Siel identified the root cause of the problem.