### PR TITLE
OUT PMcheck() bug and Report option fix

### DIFF
--- a/R/PMcheck.R
+++ b/R/PMcheck.R
@@ -280,8 +280,6 @@ PMcheck <- function(data, model, fix = F, quiet = F) {
     if (length(allMiss) > 0) {
       nonNumeric <- nonNumeric[!nonNumeric %in% allMiss]
     }
-    #exclude special case for column "OUT"
-    nonNumeric <- nonNumeric[names(nonNumeric) != 'out']
     if (length(nonNumeric) > 0) {
       err$nonNum$msg <- "FAIL - The following columns must be all numeric."
       err$nonNum$results <- nonNumeric + 1

--- a/R/PMcheck.R
+++ b/R/PMcheck.R
@@ -280,6 +280,8 @@ PMcheck <- function(data, model, fix = F, quiet = F) {
     if (length(allMiss) > 0) {
       nonNumeric <- nonNumeric[!nonNumeric %in% allMiss]
     }
+    #exclude special case for column "OUT"
+    nonNumeric <- nonNumeric[names(nonNumeric) != 'out']
     if (length(nonNumeric) > 0) {
       err$nonNum$msg <- "FAIL - The following columns must be all numeric."
       err$nonNum$results <- nonNumeric + 1

--- a/R/PMrun.R
+++ b/R/PMrun.R
@@ -606,6 +606,8 @@
       #     paste("xdg-open ", shQuote(paste(gsub("/", rep, outpath), "/", type, "report.html", sep = "")), " ; fi", sep = "")
       #   )[OS]
       }
+    } else { #close if statement if report = F
+      PMscript[getNext(PMscript)] <- ("fi", "", "fi")[OS]
     }
     
     # final clean up

--- a/R/PMrun.R
+++ b/R/PMrun.R
@@ -607,7 +607,7 @@
       #   )[OS]
       }
     } else { #close if statement if report = F
-      PMscript[getNext(PMscript)] <- ("fi", "", "fi")[OS]
+      PMscript[getNext(PMscript)] <- c("fi", "", "fi")[OS]
     }
     
     # final clean up


### PR DESCRIPTION
This PR addresses two potential issues:

- If the Pmetrics v2 usage of the OUT column is still as defined in the July 2015 User Manual (If EVID=0, there must be an entry; if missing, this must be coded as -­‐99. It will be ignored for any other EVID and therefore can be ".".), then Pmetrics v2 will fail on PMcheck() for input CSVs that use the stated "." entry for the nonNumeric test. This PR excludes the OUT column from the nonNumeric test.
- If NPrun option `report = F` then the `if` statement checking for errors doesn't get closed on OSX/Linux platforms. This PR adds an `else`  block to close it. While this does seem to be an undocumented option, it is extremely useful as we use Pmetrics on a HPC system that does not have a desktop and therefore fails at the `pander::openFileInOS` call.

Cheers,
thom