### PR TITLE
Support zero-cycle runs in the `ggplot` report template

### DIFF
--- a/inst/report/templates/ggplot.Rmd
+++ b/inst/report/templates/ggplot.Rmd
@@ -301,7 +301,7 @@ res$final$popPoints %>%
 
 ## Cycle information
 ```{r}
-if (is.null(res$cycle$AIC)) {
+if (is.null(res$cycle$aic)) {
   ggplot() +
   annotate("text",
            x = 1,

--- a/inst/report/templates/ggplot.Rmd
+++ b/inst/report/templates/ggplot.Rmd
@@ -301,7 +301,16 @@ res$final$popPoints %>%
 
 ## Cycle information
 ```{r}
-cycle_info = data.frame(
+if (is.null(res$cycle$cycnum)) {
+  ggplot() +
+  annotate("text",
+           x = 1,
+           y = 1,
+           size = 8,
+           label = "No cycles") + 
+  theme_void()
+} else {
+  cycle_info = data.frame(
   cycle = res$cycle$data$cycnum,
   ll = res$cycle$data$ll,
   AIC = res$cycle$data$aic,
@@ -388,6 +397,7 @@ EF
 plot_ll + plot_aic_bic + plot_gamlam + plot_mean + plot_sd + plot_median +
   plot_layout(design = plot_design, guides = "collect") &
   theme(legend.position = "bottom")
+}
 ```
 
 <!-- THE FOLLOWING SECTION CONTAINS JAVASCRPT SUPPORT FUNCTIONS -->

--- a/inst/report/templates/ggplot.Rmd
+++ b/inst/report/templates/ggplot.Rmd
@@ -301,7 +301,7 @@ res$final$popPoints %>%
 
 ## Cycle information
 ```{r}
-if (is.null(res$cycle$cycnum)) {
+if (is.null(res$cycle$AIC)) {
   ggplot() +
   annotate("text",
            x = 1,


### PR DESCRIPTION
Anders reported an issue where the report failed for zero-cycle runs.
This PR adds a check for those cases, and returns an empty plot in those cases for the cycle part of the report.