### PR TITLE
Update brew install script location

### DIFF
--- a/inst/mac/install_homebrew.sh
+++ b/inst/mac/install_homebrew.sh
@@ -1,1 +1,1 @@
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+ruby -e "$(curl -fsSL  https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
Brew has changed the name of the main branch from `master` to `HEAD`, as such, Brew will not install correctly on new installations of Pmetrics.

This is one way to fix it, another would be to call the install script directly as directed on the Homebrew webpage, [brew.sh](brew.sh). That script is copied below:

```bash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
```

Not tested.