### PR TITLE
Remove check for language changes in setPMoptions

### DIFF
--- a/R/PMoptions.R
+++ b/R/PMoptions.R
@@ -138,11 +138,6 @@ setPMoptions <- function(sep, dec, server_address, compilation_statements,
     PMopts <- defaultOpts
   }
 
-  if (!identical(loc, PMopts$lang)) {
-    language <- locales$language[which(locales$iso639_2 == loc)]
-    if (!quiet) cat(paste0("Language has changed. Based on system, setting default language to ", language, "."))
-  }
-
   # add missing defaults
   PMopts <- utils::modifyList(defaultOpts, PMopts)
 


### PR DESCRIPTION
This PR aims to solve issue #246.

It removes a check for the current language, but @mnneely needs to comment on wether or not this is necessary.