### PR TITLE
fix: More accurately check machine architecture

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,7 +79,7 @@ Suggests:
     reticulate,
     rmarkdown,
     testthat
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/PMconfig.R
+++ b/R/PMconfig.R
@@ -9,8 +9,13 @@ getPMpath <- function() {
 }
 
 getBits <- function() {
-  #figure out 32 or 64 bit
-  if (length(grep("64-bit", utils::sessionInfo())) > 0) { return(64) } else { return(32) }
+  if (.Machine$sizeof.pointer == 8) {
+    return(64)
+  } else if (.Machine$sizeof.pointer == 4) {
+    return(32)
+  } else {
+    stop("Unknown architecture")
+  }
 }
 
 getFixedColNames <- function() {

--- a/inst/options/PMoptions.json
+++ b/inst/options/PMoptions.json
@@ -1,7 +1,7 @@
 {
   "sep": [","],
   "dec": ["."],
-  "lang": ["C."],
+  "lang": ["C"],
   "compilation_statements": ["gfortran -march=native -w -O3 -o <exec> <files>", "gfortran -march=native -w -fopenmp -fmax-stack-var-size=32768 -O3 -o <exec> <files>"],
   "server_address": ["http://localhost:5000"],
   "backend": ["fortran"],


### PR DESCRIPTION
As reported by @graemok in #265, the old function to get the architecture was not compatible with the new Mac OS and/or hardware.