### PR TITLE
fix: Fix bug with FA and LAG

### DIFF
--- a/R/model_transpiler.R
+++ b/R/model_transpiler.R
@@ -325,7 +325,7 @@ transpile_analytic_eqn <- function(
     if (length(eqns) > 0) {
       eqns_char <- map_chr(eqns, \(x) paste(deparse(x, width.cutoff = 500L), collapse = "\n"))
       # check for ODE, which should not be present
-      if (any(stringr::str_detect(eqns_char, regex("dx\\[\\d+\\]", ignore_case = FALSE)))) {
+      if (any(stringr::str_detect(eqns_char, regex("dx\\[\\d+\\]", ignore_case = TRUE)))) {
         cli::cli_abort(c(
           "x" = "You appear to have included both a model library template and ODE.",
           "i" = "EQN block must contain ODEs or a single library model template name, not both."

--- a/R/model_transpiler.R
+++ b/R/model_transpiler.R
@@ -409,7 +409,7 @@ transpile_fa <- function(
 
   find_max_idx <- function(expr) {
     if (is.call(expr) && as.character(expr[[1]]) == "[" &&
-      as.character(expr[[2]]) == "fa" &&
+      tolower(as.character(expr[[2]])) == "fa" &&
       is.numeric(expr[[3]])) {
       return(as.integer(expr[[3]]))
     }
@@ -449,7 +449,7 @@ transpile_lag <- function(
 
   find_max_idx <- function(expr) {
     if (is.call(expr) && as.character(expr[[1]]) == "[" &&
-      as.character(expr[[2]]) == "lag" &&
+      tolower(as.character(expr[[2]])) == "lag" &&
       is.numeric(expr[[3]])) {
       return(as.integer(expr[[3]]))
     }


### PR DESCRIPTION
Helper functions to determine max index was case-sensitive, so if a user wrote

```R
fa = function(){
  FA[1] = FA1
},
```

it caused the model to not compile.
But this worked by chance, because the array was 1-dimensional by standard

```R
fa = function(){
  FA[0] = FA1
},
```

The fix is easy - to always convert the model to lowercase before transpilation and compilation.