### PR TITLE
chore: Update logs to be more informative

### DIFF
--- a/src/rust/src/logs.rs
+++ b/src/rust/src/logs.rs
@@ -6,6 +6,7 @@ use extendr_api::prelude::*;
 use extendr_api::rprintln;
 use tracing::Level;
 use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
 // Global timer that can be reset
@@ -35,15 +36,50 @@ impl RFormatLayer {
     }
 }
 
+/// Storage attached to each span containing its formatted name + fields,
+/// e.g. `cycle{cycle=3}` or just `cycle` if there are no fields.
+struct SpanFields(String);
+
 impl<S> Layer<S> for RFormatLayer
 where
-    S: tracing::Subscriber,
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn on_event(
+    fn on_new_span(
         &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        let Some(span) = ctx.span(id) else { return };
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+
+        let formatted = format_span(span.name(), &visitor.fields);
+        span.extensions_mut().insert(SpanFields(formatted));
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let Some(span) = ctx.span(id) else { return };
+        let mut visitor = FieldVisitor::default();
+        values.record(&mut visitor);
+        if visitor.fields.is_empty() {
+            return;
+        }
+        let formatted = format_span(span.name(), &visitor.fields);
+        let mut ext = span.extensions_mut();
+        if let Some(existing) = ext.get_mut::<SpanFields>() {
+            existing.0 = formatted;
+        } else {
+            ext.insert(SpanFields(formatted));
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         // Format the event
         let metadata = event.metadata();
         let level = metadata.level();
@@ -68,14 +104,48 @@ where
             Level::TRACE => "\x1b[35mTRACE\x1b[0m", // Magenta
         };
 
+        // Walk the span scope from root -> current and collect formatted spans.
+        // Each non-empty span is rendered as its own bracketed group, e.g. [Cycle 6].
+        let mut span_str = String::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                let label = span
+                    .extensions()
+                    .get::<SpanFields>()
+                    .map(|s| s.0.clone())
+                    .unwrap_or_else(|| span.name().to_string());
+                if label.is_empty() {
+                    continue;
+                }
+                // Cyan color so the span context stands out from the message
+                span_str.push_str(&format!(" \x1b[36m[{}]\x1b[0m", label));
+            }
+        }
+
         let message = if visitor.fields.is_empty() {
-            format!("[{}] [{}] (no fields)", time_buffer, level_str)
+            format!("[{}] [{}]{} (no fields)", time_buffer, level_str, span_str)
         } else {
-            format!("[{}] [{}] {}", time_buffer, level_str, visitor.fields)
+            format!(
+                "[{}] [{}]{} {}",
+                time_buffer, level_str, span_str, visitor.fields
+            )
         };
 
         // Use rprintln to print to R console
         rprintln!("{}", message);
+    }
+}
+
+/// Build a pretty span label from its name + recorded fields.
+/// - Empty span name: use the fields verbatim (handles `info_span!("", "Cycle {}", n)`).
+/// - No fields: just the span name.
+/// - Both: `name{fields}`.
+fn format_span(name: &str, fields: &str) -> String {
+    match (name.is_empty(), fields.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => fields.to_string(),
+        (false, true) => name.to_string(),
+        (false, false) => format!("{}{{{}}}", name, fields),
     }
 }
 
@@ -89,6 +159,9 @@ impl tracing::field::Visit for FieldVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
         // Special handling for "message" field - just show the value
         if field.name() == "message" {
+            if !self.fields.is_empty() {
+                self.fields.push_str(" ");
+            }
             self.fields.push_str(&format!("{:?}", value));
         } else {
             // For other fields, include the field name


### PR DESCRIPTION
Update logs to include cycle number, now showing as

```Rust
[00h 00m 00s] [INFO] [Cycle 1] Objective function = 1202.7813
[00h 00m 00s] [INFO] [Cycle 2] Objective function = 1039.6302
[00h 00m 00s] [INFO] [Cycle 3] Objective function = 848.5427
```

compared to the current

```Rust
[00h 00m 03s] [INFO] Objective function = 17957.7764
[00h 00m 04s] [INFO] Objective function = 17918.7545
[00h 00m 04s] [INFO] Objective function = 17917.0239
```

