### PR TITLE
fix: guard EVID 4 block sorting when evid column absent

### DIFF
--- a/R/PM_data.R
+++ b/R/PM_data.R
@@ -437,13 +437,17 @@ private = list(
   ungroup() %>%
   select(-block)
     
-  dataObj_orig <- dataObj_orig %>%
-  group_by(id) %>%
-  mutate(block = cumsum(evid == 4)) %>%
-  group_by(id, block) %>%
-  arrange(time, desc(evid), .by_group = TRUE) %>%
-  ungroup() %>%
-  select(-block)
+  if ("evid" %in% names(dataObj_orig)) {
+    dataObj_orig <- dataObj_orig %>%
+      group_by(id) %>%
+      mutate(block = cumsum(evid == 4)) %>%
+      group_by(id, block) %>%
+      arrange(time, desc(evid), .by_group = TRUE) %>%
+      ungroup() %>%
+      select(-block)
+  } else {
+    dataObj_orig <- dataObj_orig %>% arrange(id, time, out)
+  }
   
   
   validData <- PMcheck(data = list(standard = dataObj, original = dataObj_orig), path = path, fix = TRUE, quiet = quiet)


### PR DESCRIPTION
The validate() function applies block-based sorting (using cumsum(evid == 4)) to both dataObj and dataObj_orig. The latter is captured before evid is inferred from dose/out, so user data without an evid column triggered 'object evid not found' when sorting dataObj_orig.

Fall back to the previous arrange(id, time, out) when evid is not present.