### PR TITLE
fix: Install dependencies on fresh install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     clipr,
     crayon,
     dplyr,
+    DT,
     flextable,
     ggplot2,
     glue,
@@ -44,6 +45,7 @@ Imports:
     knitr,
     lifecycle,
     lubridate,
+    magrittr,
     MASS,
     openxlsx,
     parallel,
@@ -68,7 +70,6 @@ Imports:
 Additional_repositories: https://lapkb.r-universe.dev
 Suggests:
     devtools,
-    DT,
     mclust,
     PmetricsReports,
     PmetricsLitSim,

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,10 +42,10 @@ your system.
 
 ### Pmetrics
 
-`Pmetrics` is distributed on [r-universe](https://lapkb.r-universe.dev/Pmetrics), and built for Windows, MacOS, and Linux. To install, you must specify `r-universe` as the repository using
+`Pmetrics` is distributed on [r-universe](https://lapkb.r-universe.dev/Pmetrics), and built for Windows, MacOS, and Linux. To install, specify both the `r-universe` and CRAN repositories so that Pmetrics and its dependencies can all be found:
 
 ```r
-install.packages("Pmetrics", repos = "https://lapkb.r-universe.dev")
+install.packages("Pmetrics", repos = c("https://lapkb.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 For updating the package and for easier future installations, you can run the following command

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ your system.
 
 `Pmetrics` is distributed on
 [r-universe](https://lapkb.r-universe.dev/Pmetrics), and built for
-Windows, MacOS, and Linux. To install, you must specify `r-universe` as
-the repository using
+Windows, MacOS, and Linux. To install, specify both the `r-universe` and
+CRAN repositories so that Pmetrics and its dependencies can all be
+found:
 
 ``` r
-install.packages("Pmetrics", repos = "https://lapkb.r-universe.dev")
+install.packages("Pmetrics", repos = c("https://lapkb.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 For updating the package and for easier future installations, you can


### PR DESCRIPTION
Pmetrics will ask the user to update their R installation if outdated. If Pmetrics is installed in a fresh environment, and only the R-universe repo is defined, some dependencies are not available, and not installed, even if the Description lists them as imports. The solution is to add CRAN to the install script.