### PR TITLE
chore: Use PMcore 0.26.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "pharmsol"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517dcb31d91e7ef22317abc4a636602a27c96fe895306e5e66a6618c79a8b259"
+checksum = "0900c715396930974e65a3afcd6870b9bfb20f64fff58f85e892acaa84460128"
 dependencies = [
  "ahash",
  "argmin",
@@ -1488,19 +1488,20 @@ dependencies = [
 
 [[package]]
 name = "pharmsol-dsl"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bc3d888e264fe8b8ff3beb013b6cc5a7e7aef7e7183125ceacc287e39cca1a"
+checksum = "d6b6a128eb248ea8c3380b6494287043a4897f996cc31edd31f46b6b198c2060"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "pharmsol-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe9df0be821a8064e4b95e30d17edac93461ab6e1514b17db154047ff6a1e12"
+checksum = "94a0f0d3c3248ead2fbbabbad7591f0758d9e0820b40821bcbf231d583deb396"
 dependencies = [
  "pharmsol-dsl",
  "proc-macro2",
@@ -1529,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "pmcore"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f104417c52358763982b02c1617499f1ad6349d5e6f342d504f477d98166676"
+checksum = "282b27fdcb5b2d65c016262413fe7aaf2918461e374515717dd32fc95537c5ea"
 dependencies = [
  "anyhow",
  "argmin",

--- a/R/PM_report.R
+++ b/R/PM_report.R
@@ -22,6 +22,21 @@
   requireNamespace(package, quietly = TRUE)
 }
 
+# Environment used to track state for the current R session, e.g. whether
+# a given warning has already been shown once this session.
+.report_session_state <- new.env(parent = emptyenv())
+
+#' @param key Character string uniquely identifying the warning.
+#' @param message A named character vector passed to `cli::cli_warn()`.
+#' @noRd
+.report_warn_once <- function(key, message) {
+  if (isTRUE(.report_session_state[[key]])) {
+    return(invisible(NULL))
+  }
+  .report_session_state[[key]] <- TRUE
+  cli::cli_warn(message)
+}
+
 .report_app_runner <- function() {
   getExportedValue("PmetricsReports", "run_app")
 }
@@ -164,7 +179,7 @@ PM_report <- function(x, template, path, show = TRUE, quiet = TRUE) {
   }
 
   if (!.report_dependency_available("PmetricsReports")) {
-    cli::cli_warn(c(
+    .report_warn_once("PmetricsReports_unavailable", c(
       "!" = "The {.pkg PmetricsReports} package is not available.",
       "i" = "Falling back to legacy HTML report generation.",
       "i" = "{.code install.packages('PmetricsReports', repos = 'https://lapkb.r-universe.dev')} for a better experience."

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = 'pm_rs'
 
 [dependencies]
 extendr-api = "=0.9.0"
-pmcore = { version = "0.26.1", features = ["dsl-jit"] }
+pmcore = { version = "0.26.2", features = ["dsl-jit"] }
 
 rayon = "1.12.0"
 anyhow = "1.0.103"


### PR DESCRIPTION
Also introduces a flag that ensures that the user is only warned about a missing PmetricsReports package only once per session.