### PR TITLE
chore: Bump PMcore to 0.26.3

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,9 @@ name: R Package Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::roxygen2, any::testthat, any::mclust, any::npde
+          extra-packages: any::rcmdcheck, roxygen2@8.1.0, any::testthat, any::mclust, any::npde
           needs: check
           dependencies: '"hard"'
         continue-on-error: true
@@ -69,7 +69,7 @@ jobs:
         if: steps.install-deps.outcome == 'failure'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::roxygen2, any::testthat, any::mclust, any::npde
+          extra-packages: any::rcmdcheck, roxygen2@8.1.0, any::testthat, any::mclust, any::npde
           needs: check
           dependencies: '"hard"'
 
@@ -87,6 +87,6 @@ jobs:
       - name: Check package
         uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: "\"error\""
-          args: "c(\"--no-manual\", \"--ignore-vignettes\", \"--as-cran\")"
-          build_args: "c(\"--no-manual\", \"--no-build-vignettes\")"
+          error-on: '"error"'
+          args: 'c("--no-manual", "--ignore-vignettes", "--as-cran")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde609ad0d2ac3255f3363fad230a7f4c6dfd2ff4bf26381c53e459cc7a4fe89"
+checksum = "741d806a79cf99eaf51384a8800bbb4252a0428d6a29cdba1ab7e93b2c7ddb41"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -212,27 +212,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
+checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
+checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
+checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -240,18 +240,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
+checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
+checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -263,7 +263,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
  "regalloc2",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
+checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -288,24 +288,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
+checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
+checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
+checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -313,11 +313,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
+checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -325,15 +326,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
+checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96aa44fbb64b5b652fd77aa0a5bb3a1609ca4eae7204fd547991245cc19a18d0"
+checksum = "2336d9ac773a092b1bff25988b298fe47d7921c2e6019d8243f5bb52d1c78d0d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -343,6 +344,7 @@ dependencies = [
  "cranelift-native",
  "libc",
  "log",
+ "memmap2",
  "region",
  "target-lexicon",
  "wasmtime-internal-jit-icache-coherence",
@@ -351,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab212cf4630da14726d76333152920694c52f544ff5cc520329b4fa256fe78c"
+checksum = "8c89882b932e6ae6b9c9a9c0d4ee784c53208d2db5cccb6e099e298cf35572cf"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -362,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
+checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -373,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
+checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
 name = "crossbeam"
@@ -487,19 +489,42 @@ dependencies = [
 
 [[package]]
 name = "diffsol"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a780f5b416f2ba4d2df970e4e157ee7de9bff20862bd17df79912b231e4770"
+checksum = "5df81c513abe1e17db8a8b2f6da885ead5dc979fb154e95e9b6ea522bc2370fc"
 dependencies = [
- "faer",
- "faer-traits",
+ "diffsol-la",
+ "diffsol-nl",
  "log",
- "nalgebra 0.35.0",
- "nalgebra-sparse",
  "num-traits",
  "petgraph",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "diffsol-la"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd42e083ac1b3ea85db099025a33eb802cf0f186cb3a8eb2d7809597f0e2097f"
+dependencies = [
+ "faer",
+ "faer-traits",
+ "nalgebra",
+ "num-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "diffsol-nl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f90f3f8e82154b9e984a21816867d840c0b1c1d2a150a3a477d331b020aa0e"
+dependencies = [
+ "diffsol-la",
+ "log",
+ "num-traits",
  "thiserror 2.0.18",
 ]
 
@@ -864,17 +889,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -962,15 +976,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1125,29 +1139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.6",
- "rand_distr 0.4.3",
- "simba 0.9.1",
- "typenum",
 ]
 
 [[package]]
@@ -1166,7 +1172,8 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.10.0",
+ "rand 0.10.1",
+ "simba",
  "typenum",
 ]
 
@@ -1179,18 +1186,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "nalgebra-sparse"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8935b578b6a012f3667131452add895472f37c242d2844497daf7c49f6b8059"
-dependencies = [
- "nalgebra 0.35.0",
- "num-traits",
- "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -1458,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "pharmsol"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0900c715396930974e65a3afcd6870b9bfb20f64fff58f85e892acaa84460128"
+checksum = "8c86fd5100ad080908c3e82d1530cac0871ce15c94395b23aca67f67ea743018"
 dependencies = [
  "ahash",
  "argmin",
@@ -1471,7 +1466,8 @@ dependencies = [
  "cranelift-native",
  "csv",
  "diffsol",
- "nalgebra 0.35.0",
+ "diffsol-la",
+ "nalgebra",
  "ndarray",
  "pharmsol-dsl",
  "pharmsol-macros",
@@ -1488,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "pharmsol-dsl"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6a128eb248ea8c3380b6494287043a4897f996cc31edd31f46b6b198c2060"
+checksum = "0d4c0775432277262cc292a595e57226f0ebcb8607ffd4aaacfcc74b0bbe4d89"
 dependencies = [
  "serde",
  "serde_json",
@@ -1499,11 +1495,12 @@ dependencies = [
 
 [[package]]
 name = "pharmsol-macros"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a0f0d3c3248ead2fbbabbad7591f0758d9e0820b40821bcbf231d583deb396"
+checksum = "7aee09410f8d55ddeed7350796e086f45b9f508b34d9e85e3e5927e728dca757"
 dependencies = [
  "pharmsol-dsl",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 3.0.2",
@@ -1530,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "pmcore"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282b27fdcb5b2d65c016262413fe7aaf2918461e374515717dd32fc95537c5ea"
+checksum = "71f1909931c189b25bd95df953b5247b0e08ae783b2298d81debf9d8210ea360"
 dependencies = [
  "anyhow",
  "argmin",
@@ -1603,6 +1600,15 @@ dependencies = [
  "rayon",
  "spindle",
  "sysctl",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1701,8 +1707,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1712,7 +1716,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -1725,16 +1729,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1752,9 +1746,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -1770,16 +1761,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
 
 [[package]]
 name = "rand_distr"
@@ -1934,15 +1915,6 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "safe_arch"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
@@ -2054,19 +2026,6 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide 0.7.33",
-]
-
-[[package]]
-name = "simba"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
@@ -2074,7 +2033,7 @@ dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "wide 1.5.0",
+ "wide",
 ]
 
 [[package]]
@@ -2110,14 +2069,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "statrs"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+checksum = "c78553aa710187998fc7c7945c18889c59ef199ff7d2146ab90998b431b29eea"
 dependencies = [
  "approx",
- "nalgebra 0.33.3",
+ "nalgebra",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2254,6 +2214,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,12 +2352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,19 +2450,19 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
+checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
+checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2498,22 +2482,12 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch 0.7.4",
-]
-
-[[package]]
-name = "wide"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
- "safe_arch 1.1.0",
+ "safe_arch",
 ]
 
 [[package]]
@@ -2678,6 +2652,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: Pmetrics
 Title: Pmetrics for Population Modeling and Simulation
-Version: 3.2.2
+Version: 3.2.3
 Authors@R: c(
     person("Michael", "Neely", , "mneely@usc.edu", role = c("aut", "cre")),
     person("Julián", "Otálvaro", , "juliandavid347@gmail.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,7 +82,7 @@ VignetteBuilder:
     knitr
 Config/Needs/website: r-lib/pkgdown, quarto
 Config/rextendr/version: 0.5.0
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -158,250 +158,280 @@ export(two_comp_iv)
 export(two_comp_iv_cl)
 export(zBMI)
 importFrom(R6,R6Class)
-importFrom(bslib,accordion)
-importFrom(bslib,accordion_panel)
-importFrom(bslib,card)
-importFrom(bslib,nav_panel)
-importFrom(bslib,navset_card_tab)
-importFrom(dplyr,across)
-importFrom(dplyr,all_of)
-importFrom(dplyr,arrange)
-importFrom(dplyr,as_tibble)
-importFrom(dplyr,bind_cols)
-importFrom(dplyr,bind_rows)
-importFrom(dplyr,case_match)
-importFrom(dplyr,case_when)
-importFrom(dplyr,distinct)
-importFrom(dplyr,everything)
-importFrom(dplyr,filter)
-importFrom(dplyr,group_by)
-importFrom(dplyr,group_map)
-importFrom(dplyr,if_else)
-importFrom(dplyr,inner_join)
-importFrom(dplyr,mutate)
-importFrom(dplyr,n)
-importFrom(dplyr,nest_by)
-importFrom(dplyr,pull)
-importFrom(dplyr,quo)
-importFrom(dplyr,reframe)
-importFrom(dplyr,relocate)
-importFrom(dplyr,rename)
-importFrom(dplyr,row_number)
-importFrom(dplyr,rowwise)
-importFrom(dplyr,select)
-importFrom(dplyr,slice)
-importFrom(dplyr,slice_head)
-importFrom(dplyr,slice_tail)
-importFrom(dplyr,starts_with)
-importFrom(dplyr,summarize)
-importFrom(dplyr,tibble)
-importFrom(dplyr,ungroup)
-importFrom(dplyr,where)
-importFrom(ggplot2,aes)
-importFrom(ggplot2,aes_string)
-importFrom(ggplot2,coord_fixed)
-importFrom(ggplot2,element_blank)
-importFrom(ggplot2,element_text)
-importFrom(ggplot2,facet_wrap)
-importFrom(ggplot2,geom_hline)
-importFrom(ggplot2,geom_label)
-importFrom(ggplot2,geom_line)
-importFrom(ggplot2,geom_point)
-importFrom(ggplot2,geom_polygon)
-importFrom(ggplot2,geom_rect)
-importFrom(ggplot2,geom_segment)
-importFrom(ggplot2,geom_smooth)
-importFrom(ggplot2,ggplot)
-importFrom(ggplot2,ggtitle)
-importFrom(ggplot2,labs)
-importFrom(ggplot2,scale_color_identity)
-importFrom(ggplot2,scale_fill_identity)
-importFrom(ggplot2,scale_x_continuous)
-importFrom(ggplot2,scale_x_log10)
-importFrom(ggplot2,scale_y_continuous)
-importFrom(ggplot2,scale_y_log10)
-importFrom(ggplot2,theme)
-importFrom(ggplot2,theme_bw)
-importFrom(ggplot2,theme_grey)
-importFrom(ggplot2,theme_void)
-importFrom(ggplot2,xlab)
-importFrom(ggplot2,xlim)
-importFrom(ggplot2,ylab)
-importFrom(ggplot2,ylim)
-importFrom(grDevices,col2rgb)
-importFrom(grDevices,dev.off)
-importFrom(grDevices,devAskNewPage)
-importFrom(grDevices,gray.colors)
-importFrom(grDevices,jpeg)
-importFrom(grDevices,pdf)
-importFrom(grDevices,png)
-importFrom(grDevices,postscript)
-importFrom(grDevices,rgb)
-importFrom(grDevices,setEPS)
-importFrom(graphics,abline)
-importFrom(graphics,arrows)
-importFrom(graphics,axTicks)
-importFrom(graphics,axis)
-importFrom(graphics,boxplot)
-importFrom(graphics,hist)
-importFrom(graphics,legend)
-importFrom(graphics,lines)
-importFrom(graphics,par)
-importFrom(graphics,plot)
-importFrom(graphics,points)
-importFrom(graphics,polygon)
-importFrom(graphics,rect)
-importFrom(graphics,rug)
-importFrom(graphics,segments)
-importFrom(graphics,text)
-importFrom(parallel,clusterExport)
-importFrom(parallel,makeCluster)
-importFrom(parallel,parLapply)
-importFrom(parallel,stopCluster)
-importFrom(plotly,add_annotations)
-importFrom(plotly,add_bars)
-importFrom(plotly,add_lines)
-importFrom(plotly,add_markers)
-importFrom(plotly,add_trace)
-importFrom(plotly,filter)
-importFrom(plotly,ggplotly)
-importFrom(plotly,layout)
-importFrom(plotly,mutate)
-importFrom(plotly,plot_ly)
-importFrom(plotly,plotly_build)
-importFrom(plotly,renderPlotly)
-importFrom(plotly,subplot)
+importFrom(bslib,
+  accordion,
+  accordion_panel,
+  card,
+  nav_panel,
+  navset_card_tab
+)
+importFrom(dplyr,
+  across,
+  all_of,
+  arrange,
+  as_tibble,
+  bind_cols,
+  bind_rows,
+  case_match,
+  case_when,
+  distinct,
+  everything,
+  filter,
+  group_by,
+  group_map,
+  if_else,
+  inner_join,
+  mutate,
+  n,
+  nest_by,
+  pull,
+  quo,
+  reframe,
+  relocate,
+  rename,
+  row_number,
+  rowwise,
+  select,
+  slice,
+  slice_head,
+  slice_tail,
+  starts_with,
+  summarize,
+  tibble,
+  ungroup,
+  where
+)
+importFrom(ggplot2,
+  aes,
+  aes_string,
+  coord_fixed,
+  element_blank,
+  element_text,
+  facet_wrap,
+  geom_hline,
+  geom_label,
+  geom_line,
+  geom_point,
+  geom_polygon,
+  geom_rect,
+  geom_segment,
+  geom_smooth,
+  ggplot,
+  ggtitle,
+  labs,
+  scale_color_identity,
+  scale_fill_identity,
+  scale_x_continuous,
+  scale_x_log10,
+  scale_y_continuous,
+  scale_y_log10,
+  theme,
+  theme_bw,
+  theme_grey,
+  theme_void,
+  xlab,
+  xlim,
+  ylab,
+  ylim
+)
+importFrom(grDevices,
+  col2rgb,
+  dev.off,
+  devAskNewPage,
+  gray.colors,
+  jpeg,
+  pdf,
+  png,
+  postscript,
+  rgb,
+  setEPS
+)
+importFrom(graphics,
+  abline,
+  arrows,
+  axTicks,
+  axis,
+  boxplot,
+  hist,
+  legend,
+  lines,
+  par,
+  plot,
+  points,
+  polygon,
+  rect,
+  rug,
+  segments,
+  text
+)
+importFrom(parallel,
+  clusterExport,
+  makeCluster,
+  parLapply,
+  stopCluster
+)
+importFrom(plotly,
+  add_annotations,
+  add_bars,
+  add_lines,
+  add_markers,
+  add_trace,
+  filter,
+  ggplotly,
+  layout,
+  mutate,
+  plot_ly,
+  plotly_build,
+  renderPlotly,
+  subplot
+)
 importFrom(progress,progress_bar)
-importFrom(purrr,keep)
-importFrom(purrr,list_rbind)
-importFrom(purrr,map)
-importFrom(purrr,map2)
-importFrom(purrr,map_chr)
-importFrom(purrr,map_df)
-importFrom(purrr,map_lgl)
-importFrom(purrr,pluck)
-importFrom(purrr,reduce)
-importFrom(readr,read_file)
-importFrom(readr,write_file)
-importFrom(rlang,":=")
-importFrom(rlang,.data)
-importFrom(rlang,set_names)
-importFrom(shiny,HTML)
-importFrom(shiny,actionButton)
-importFrom(shiny,br)
-importFrom(shiny,checkboxInput)
-importFrom(shiny,column)
-importFrom(shiny,conditionalPanel)
-importFrom(shiny,div)
-importFrom(shiny,fileInput)
-importFrom(shiny,fluidPage)
-importFrom(shiny,fluidRow)
-importFrom(shiny,h2)
-importFrom(shiny,h3)
-importFrom(shiny,h4)
-importFrom(shiny,h5)
-importFrom(shiny,helpText)
-importFrom(shiny,hr)
-importFrom(shiny,htmlOutput)
-importFrom(shiny,icon)
-importFrom(shiny,markdown)
-importFrom(shiny,modalDialog)
-importFrom(shiny,navlistPanel)
-importFrom(shiny,numericInput)
-importFrom(shiny,observeEvent)
-importFrom(shiny,plotOutput)
-importFrom(shiny,radioButtons)
-importFrom(shiny,reactive)
-importFrom(shiny,reactiveVal)
-importFrom(shiny,renderUI)
-importFrom(shiny,selectInput)
-importFrom(shiny,shinyApp)
-importFrom(shiny,showModal)
-importFrom(shiny,tabPanel)
-importFrom(shiny,tags)
-importFrom(shiny,textAreaInput)
-importFrom(shiny,textInput)
-importFrom(shiny,textOutput)
-importFrom(shiny,titlePanel)
-importFrom(shiny,uiOutput)
-importFrom(shiny,updateNumericInput)
-importFrom(shiny,updateSelectInput)
-importFrom(shiny,updateSelectizeInput)
-importFrom(shiny,updateTextAreaInput)
-importFrom(stats,aggregate)
-importFrom(stats,anova)
-importFrom(stats,approx)
-importFrom(stats,as.formula)
-importFrom(stats,binom.test)
-importFrom(stats,coef)
-importFrom(stats,complete.cases)
-importFrom(stats,confint)
-importFrom(stats,cor)
-importFrom(stats,cor.test)
-importFrom(stats,cov)
-importFrom(stats,cov.wt)
-importFrom(stats,cov2cor)
-importFrom(stats,density)
-importFrom(stats,dnorm)
-importFrom(stats,get_all_vars)
-importFrom(stats,glm)
-importFrom(stats,kmeans)
-importFrom(stats,kruskal.test)
-importFrom(stats,ks.test)
-importFrom(stats,lm)
-importFrom(stats,median)
-importFrom(stats,model.frame)
-importFrom(stats,pchisq)
-importFrom(stats,pnorm)
-importFrom(stats,predict)
-importFrom(stats,pt)
-importFrom(stats,qchisq)
-importFrom(stats,qnorm)
-importFrom(stats,qqline)
-importFrom(stats,qqnorm)
-importFrom(stats,qqplot)
-importFrom(stats,qt)
-importFrom(stats,quantile)
-importFrom(stats,rnorm)
-importFrom(stats,runif)
-importFrom(stats,sd)
-importFrom(stats,shapiro.test)
-importFrom(stats,step)
-importFrom(stats,t.test)
-importFrom(stats,terms)
-importFrom(stats,time)
-importFrom(stats,var)
-importFrom(stats,weighted.mean)
-importFrom(stats,wilcox.test)
-importFrom(stringr,regex)
-importFrom(stringr,str_glue)
-importFrom(stringr,str_replace)
-importFrom(tidyr,crossing)
-importFrom(tidyr,extract)
-importFrom(tidyr,fill)
-importFrom(tidyr,nest)
-importFrom(tidyr,pivot_longer)
-importFrom(tidyr,pivot_wider)
-importFrom(tidyr,separate)
-importFrom(tidyr,separate_wider_delim)
-importFrom(tidyr,unnest)
-importFrom(tidyr,unnest_longer)
-importFrom(utils,compareVersion)
-importFrom(utils,data)
-importFrom(utils,flush.console)
-importFrom(utils,getTxtProgressBar)
-importFrom(utils,glob2rx)
-importFrom(utils,head)
-importFrom(utils,install.packages)
-importFrom(utils,modifyList)
-importFrom(utils,news)
-importFrom(utils,packageVersion)
-importFrom(utils,read.table)
-importFrom(utils,setTxtProgressBar)
-importFrom(utils,str)
-importFrom(utils,tail)
-importFrom(utils,txtProgressBar)
-importFrom(utils,write.csv)
-importFrom(utils,write.table)
+importFrom(purrr,
+  keep,
+  list_rbind,
+  map,
+  map2,
+  map_chr,
+  map_df,
+  map_lgl,
+  pluck,
+  reduce
+)
+importFrom(readr,
+  read_file,
+  write_file
+)
+importFrom(rlang,
+  ":=",
+  .data,
+  set_names
+)
+importFrom(shiny,
+  HTML,
+  actionButton,
+  br,
+  checkboxInput,
+  column,
+  conditionalPanel,
+  div,
+  fileInput,
+  fluidPage,
+  fluidRow,
+  h2,
+  h3,
+  h4,
+  h5,
+  helpText,
+  hr,
+  htmlOutput,
+  icon,
+  markdown,
+  modalDialog,
+  navlistPanel,
+  numericInput,
+  observeEvent,
+  plotOutput,
+  radioButtons,
+  reactive,
+  reactiveVal,
+  renderUI,
+  selectInput,
+  shinyApp,
+  showModal,
+  tabPanel,
+  tags,
+  textAreaInput,
+  textInput,
+  textOutput,
+  titlePanel,
+  uiOutput,
+  updateNumericInput,
+  updateSelectInput,
+  updateSelectizeInput,
+  updateTextAreaInput
+)
+importFrom(stats,
+  aggregate,
+  anova,
+  approx,
+  as.formula,
+  binom.test,
+  coef,
+  complete.cases,
+  confint,
+  cor,
+  cor.test,
+  cov,
+  cov.wt,
+  cov2cor,
+  density,
+  dnorm,
+  get_all_vars,
+  glm,
+  kmeans,
+  kruskal.test,
+  ks.test,
+  lm,
+  median,
+  model.frame,
+  pchisq,
+  pnorm,
+  predict,
+  pt,
+  qchisq,
+  qnorm,
+  qqline,
+  qqnorm,
+  qqplot,
+  qt,
+  quantile,
+  rnorm,
+  runif,
+  sd,
+  shapiro.test,
+  step,
+  t.test,
+  terms,
+  time,
+  var,
+  weighted.mean,
+  wilcox.test
+)
+importFrom(stringr,
+  regex,
+  str_glue,
+  str_replace
+)
+importFrom(tidyr,
+  crossing,
+  extract,
+  fill,
+  nest,
+  pivot_longer,
+  pivot_wider,
+  separate,
+  separate_wider_delim,
+  unnest,
+  unnest_longer
+)
+importFrom(utils,
+  compareVersion,
+  data,
+  flush.console,
+  getTxtProgressBar,
+  glob2rx,
+  head,
+  install.packages,
+  modifyList,
+  news,
+  packageVersion,
+  read.table,
+  setTxtProgressBar,
+  str,
+  tail,
+  txtProgressBar,
+  write.csv,
+  write.table
+)
 importFrom(withr,with_dir)
 useDynLib(Pmetrics, .registration = TRUE)

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = 'pm_rs'
 
 [dependencies]
 extendr-api = "=0.9.0"
-pmcore = { version = "0.26.2", features = ["dsl-jit"] }
+pmcore = { version = "0.26.3", features = ["dsl-jit"] }
 
 rayon = "1.12.0"
 anyhow = "1.0.103"


### PR DESCRIPTION
This includes the fixes made in Pharmsol to address some issues with the simulator, like the Newton method not converging