### PR TITLE
fix: Improve error message for bolus scaling

### DIFF
--- a/R/model_dsl.R
+++ b/R/model_dsl.R
@@ -78,10 +78,19 @@ expr_to_dsl <- function(expr, allow_if = TRUE) {
     }
     idx <- as.integer(idx_raw)
     if (var %in% c("b", "bolus", "rateiv", "r")) {
-      cli::cli_abort(c(
+      # A bolus is a discrete state jump and an infusion rate is injected by the
+      # backend from the route declaration, so neither is a value the DSL can
+      # multiply; dose scaling goes through the bolus-only `fa` property.
+      msg <- c(
         "x" = "Bolus/infusion inputs may only be used as standalone additive terms in derivative equations.",
         "i" = "Write, for example, {.code dx[1] = -ke * x[1] + rateiv[1]}, not inside a product."
-      ))
+      )
+      if (var %in% c("b", "bolus")) {
+        msg <- c(msg,
+          "i" = "To scale a bolus dose up or down (e.g. bioavailability), use the {.arg fa} block: {.code fa = function() {{ fa[{idx}] = F }}}."
+        )
+      }
+      cli::cli_abort(msg)
     }
     return(sprintf("%s%d", var, idx))
   }
@@ -352,12 +361,48 @@ dsl_sec_block <- function(fun) {
   derived
 }
 
+# Collect the scalar assignments of a block as a named list of R expressions,
+# keyed by lower-cased variable name.
+dsl_scalar_defs <- function(fun) {
+  defs <- list()
+  if (is.null(fun)) {
+    return(defs)
+  }
+  for (e in dsl_body_stmts(fun)) {
+    if (dsl_is_assign(e) && is.symbol(e[[2]])) {
+      defs[[tolower(as.character(e[[2]]))]] <- e[[3]]
+    }
+  }
+  defs
+}
+
+# Substitute the definitions in `defs` into `expr`, recursively.
+dsl_inline_defs <- function(expr, defs, seen = character(0)) {
+  if (is.symbol(expr)) {
+    name <- tolower(as.character(expr))
+    if (is.null(defs[[name]])) {
+      return(expr)
+    }
+    if (name %in% seen) {
+      cli::cli_abort("Secondary equation {.code {name}} is defined in terms of itself.")
+    }
+    return(call("(", dsl_inline_defs(defs[[name]], defs, c(seen, name))))
+  }
+  if (is.call(expr) && length(expr) > 1) {
+    for (i in seq_along(expr)[-1]) {
+      expr[[i]] <- dsl_inline_defs(expr[[i]], defs, seen)
+    }
+  }
+  expr
+}
+
 # Emit route-property modifiers (`lag(...)` / `fa(...)`) from a lag/fa block.
 # `target` is the DSL property name ("lag" or "fa"); the R block assigns to
-# `lag[j]` / `fa[j]` where `j` is the 1-based input index.
-dsl_route_property_block <- function(fun, target) {
+# `lag[j]` / `fa[j]` where `j` is the 1-based input index. `defs` holds the
+# secondary equations, which pharmsol does not put in scope for route
+# properties, so they are inlined into the emitted expression instead.
+dsl_route_property_block <- function(fun, target, defs = list()) {
   exprs <- dsl_body_stmts(fun)
-  derived <- character(0)
   lines <- character(0)
   for (e in exprs) {
     if (!dsl_is_assign(e)) {
@@ -371,12 +416,16 @@ dsl_route_property_block <- function(fun, target) {
       if (tgt != target) {
         cli::cli_abort("Unexpected indexed assignment to {.code {tgt}[{idx}]} in {target} block.")
       }
-      lines <- c(lines, sprintf("%s(%s) = %s", target, pm_input_label(idx), expr_to_dsl(rhs)))
+      lines <- c(lines, sprintf(
+        "%s(%s) = %s", target, pm_input_label(idx),
+        expr_to_dsl(dsl_inline_defs(rhs, defs))
+      ))
     } else {
-      derived <- c(derived, sprintf("%s = %s", tolower(as.character(lhs)), expr_to_dsl(rhs)))
+      # Block-local helpers are only visible inside this block.
+      defs[[tolower(as.character(lhs))]] <- dsl_inline_defs(rhs, defs)
     }
   }
-  list(derived = derived, lines = lines)
+  lines
 }
 
 # Emit `init(...)` statements from an initial-conditions block.
@@ -595,18 +644,16 @@ model_to_dsl <- function(model) {
     init_lines <- ini$lines
   }
 
+  sec_defs <- dsl_scalar_defs(arg_list$sec)
+
   lag_lines <- character(0)
   if (!is.null(arg_list$lag)) {
-    lag <- dsl_route_property_block(arg_list$lag, "lag")
-    derived <- c(derived, lag$derived)
-    lag_lines <- lag$lines
+    lag_lines <- dsl_route_property_block(arg_list$lag, "lag", sec_defs)
   }
 
   fa_lines <- character(0)
   if (!is.null(arg_list$fa)) {
-    fa <- dsl_route_property_block(arg_list$fa, "fa")
-    derived <- c(derived, fa$derived)
-    fa_lines <- fa$lines
+    fa_lines <- dsl_route_property_block(arg_list$fa, "fa", sec_defs)
   }
 
   # Number of states and outputs.

--- a/tests/testthat/test-model-dsl-dose-scaling.R
+++ b/tests/testthat/test-model-dsl-dose-scaling.R
@@ -1,0 +1,79 @@
+testthat::skip_on_cran()
+
+model_to_dsl <- getFromNamespace("model_to_dsl", "Pmetrics")
+model_metadata <- getFromNamespace("model_metadata", "Pmetrics")
+
+scaled_bolus_model <- function(fa_block, eqn_block) {
+    PM_model$new(
+        list(
+            pri = list(
+                kes = ab(0, 5),
+                vs = ab(0, 5),
+                ff = ab(0, 1) # free fraction
+            ),
+            cov = list(wt = interp()),
+            sec = function() {
+                v <- vs * (wt / 70)
+                ke <- kes * (wt / 70)^-0.25
+            },
+            fa = fa_block,
+            eqn = eqn_block,
+            out = function() {
+                y[1] <- x[1] / v
+                y[2] <- x[2]
+            },
+            err = list(
+                additive(1, c(1, 0, 0, 0), outeq = 1),
+                additive(1, c(1, 0, 0, 0), outeq = 2)
+            )
+        ),
+        compile = FALSE
+    )
+}
+
+testthat::test_that("Scaling a bolus inside a derivative is rejected and points at `fa`", {
+    # A bolus is a discrete state jump in pharmsol, not a value in the
+    # derivative, so `B[1] * v` cannot be expressed.
+    mod <- scaled_bolus_model(
+        fa_block = NULL,
+        eqn_block = function() {
+            dx[1] <- B[1] * v + R[1] - ke * x[1] # total drug
+            dx[2] <- B[2] + x[1] / v * ff # free drug
+        }
+    )
+
+    err <- testthat::expect_error(model_to_dsl(mod))
+    msg <- gsub("\\s+", " ", conditionMessage(err))
+    testthat::expect_match(
+        msg, "standalone additive terms in derivative equations",
+        fixed = TRUE
+    )
+    testthat::expect_match(msg, "use the `fa` block", fixed = TRUE)
+})
+
+testthat::test_that("Bolus dose scaling moves to `fa` and reaches the backend", {
+    mod <- scaled_bolus_model(
+        fa_block = function() {
+            fa[1] <- v
+        },
+        eqn_block = function() {
+            dx[1] <- B[1] + R[1] - ke * x[1] # total drug
+            dx[2] <- B[2] + x[1] / v * ff # free drug
+        }
+    )
+    mod$compile(quiet = TRUE)
+
+    # Input 1 drives both a bolus and an infusion; `fa` binds to the bolus only.
+    testthat::expect_match(mod$dsl, "bolus(input_1) -> x1", fixed = TRUE)
+    testthat::expect_match(mod$dsl, "infusion(input_1) -> x1", fixed = TRUE)
+    testthat::expect_match(mod$dsl, "bolus(input_2) -> x2", fixed = TRUE)
+    # pharmsol does not put derived values in scope for route properties, so the
+    # secondary equation for `v` is inlined.
+    testthat::expect_match(mod$dsl, "fa(input_1) = (vs * (wt / 70.0))", fixed = TRUE)
+
+    metadata <- model_metadata(mod$dsl, NULL)
+    testthat::expect_identical(metadata$routes, c("input_1", "input_1", "input_2"))
+    testthat::expect_identical(metadata$route_kinds, c("bolus", "infusion", "bolus"))
+    testthat::expect_identical(metadata$covariates, "wt")
+    testthat::expect_identical(metadata$outputs, c("outeq_1", "outeq_2"))
+})


### PR DESCRIPTION
Trying to provide a better error message for users attempting to scale boluses in the equation block, rather than the fa block.

There is a weird limitation in pharmsol where the secondary equations do not seem to also be evaluated in the context of `fa`.
I added a temporary fix, help me remember so it doesn't become permanent...

Closes #385 